### PR TITLE
Polish English wording in backend posts

### DIFF
--- a/source/_posts/backend/http-graceful-cancelation.md
+++ b/source/_posts/backend/http-graceful-cancelation.md
@@ -1,6 +1,6 @@
-title: HTTP Graceful Cancelation
+title: HTTP Graceful Cancellation
 date: 2024-04-24
-tags: [XHR,HTTP,HttpClient,Nginx,HTTP/2,Cancelation,Cancel]
+tags: [XHR,HTTP,HttpClient,Nginx,HTTP/2,Cancellation,Cancel]
 categories: Backend
 toc: true
 ---
@@ -9,7 +9,7 @@ Imagine we are writing an HTTP server as described below, where the endpoint tak
 
 When a client starts a request, it may cancel it before the long-running task is completed.
 
-The question we're addressing here is: can the server be aware that the client has cancelled the request? If the server can be aware, it can stop the costly subsequent operation in advance to save server resources.
+The question we're addressing here is: can the server detect that the client has canceled the request? If the server can detect this in time, it can stop costly downstream work and save resources.
 
 ## Without Nginx
 
@@ -116,7 +116,7 @@ Working... 7
 Client has disconnected. Stopping task.  8
 ```
 
-#### How it works?
+#### How does it work?
 
 The context included with each HTTP request in Go is linked to the lifecycle of the request. If the underlying TCP connection is closed, Go’s HTTP server automatically cancels this context. The cancellation can occur due to client disconnection (TCP FIN or RST), server-side timeout, or if the server manually cancels the context for other reasons (like application logic deciding to abort the request processing).
 
@@ -228,7 +228,7 @@ Client has disconnected. Stopping task.  7
 
 ### Offline
 
-When the user suddenly makes the device offline (without any network notification e.g., TCP FIN&RST or HTTP/2 RST), what will happen?
+When a user suddenly takes the device offline (without any network notification such as TCP FIN/RST or HTTP/2 RST), what happens?
 
 We can use another device to test it.
 
@@ -275,7 +275,7 @@ Servers that support HTTP/2 or HTTP/3 are thus better equipped to handle request
 
 We usually use Nginx as a reverse proxy between the client and the server.
 
-Since we commonly use HTTP/2 on the Nginx side, so after integrating with Nginx, the process flow will be like:
+Since HTTP/2 is commonly used on the client-to-Nginx side, after integrating Nginx the traffic flow typically looks like this:
 
 ```shell
 Client - HTTP/2 -> Nginx - HTTP/1.1 -> Server
@@ -320,7 +320,7 @@ http {
 
 In the above part, we have a conclusion that both cURL and XHR can perform a graceful cancellation.
 
-So in this part, to simplify, we will just use a cURL to test these cases.
+So in this part, to simplify, we will just use curl to test these cases.
 
 #### Nginx - HTTP/1.1 -> Server
 

--- a/source/_posts/backend/innodb-locks.md
+++ b/source/_posts/backend/innodb-locks.md
@@ -8,15 +8,15 @@ toc: true
 ![MySQL](/uploads/persister-innodb-locks-MySQL-1200px-MySQL.svg.png)
 
 InnoDB is a storage engine for MySQL. 
-After more than ten years of development, InnoDB has becomed the most common storage engine in Internet compony usages.
+After more than ten years of evolution, InnoDB has become the most widely used storage engine for internet applications.
 
-There are lots of articles talk over the locks of InnoDB, and today I am going to discuss them again.
+There are many articles about InnoDB locks, and today I want to revisit the topic.
 
-## SHOW YOUR LOCKS IN MYSQL
+## HOW TO VIEW LOCKS IN MYSQL
 
 To learn the locks effectively, you should learn to show the locks of current database.
 
-Typing this command in mysql client, and you will get all of the locks whiches InnoDB is holding.
+Typing this command in mysql client, and you will get all of the locks that InnoDB is currently holding.
 
 ```sql
 mysql> select * from performance_schema.data_locks\G
@@ -38,7 +38,7 @@ OBJECT_INSTANCE_BEGIN: 140616462868960
             LOCK_DATA: NULL -- index of the lock using
 ```
 
-We have learnd the way to show the locks of current database in the code block above, and we notice that there are some key fileds whe should care about.
+As shown above, we can inspect current locks in the database. There are several key fields we should pay attention to.
 
 - INDEX_NAME The name of the locked index, always non-NULL for innoDB tables.
 - LOCK_TYPE 
@@ -46,11 +46,11 @@ We have learnd the way to show the locks of current database in the code block a
 - LOCK_STATUS
 - LOCK_DATA
 
-In these five fields, we can learn mostly all of the information we regard.
+From these five fields, we can get almost all the lock details we care about.
 
 ### LOCK_TYPE
 
-LOCK_TYPE is the first filed and the most easy field we got, it can be TABLE or RECORD, indicates that the scope of this lock affected to.
+LOCK_TYPE is the first and easiest field to understand. It can be TABLE or RECORD and indicates the scope affected by the lock.
 
 ### LOCK_MODE
 
@@ -69,8 +69,8 @@ LOCK_MODE has several options
 
 ### LOCK_STATUS
 
-LOCK_STATUS show the aquire status of this lock, could be GRANTED or WAITING.
-When the LOCK_STATUS is GRANTED means that the session aquired this lock, otherwise means that the session of this lock is waiting.
+LOCK_STATUS shows the acquisition state of this lock: GRANTED or WAITING.
+When the LOCK_STATUS is GRANTED means that the session acquired this lock, otherwise means that the session of this lock is waiting.
 
 ### LOCK_DATA
 
@@ -100,7 +100,7 @@ mysql> select * from child
 4 rows in set (0.00 sec)
 ```
 
-And then we begin an session an lock a nonexistent row.
+Then we start a session and lock a non-existent row.
 ```
 mysql> begin;
 Query OK, 0 rows affected (0.00 sec)
@@ -109,7 +109,7 @@ mysql> select * from child where id = 100 for update;
 Empty set (0.00 sec)
 ```
 
-When we query the locks of this database, we can see that the (90, 102) have been lock as Exclusive Gap Lock.
+When we query the locks of this database, we can see that the (90, 102) has been locked as an Exclusive Gap Lock.
 
 ```
 mysql> select * from performance_schema.data_locks\G

--- a/source/_posts/backend/livestreaming/scalable-interactive-service-1.md
+++ b/source/_posts/backend/livestreaming/scalable-interactive-service-1.md
@@ -7,19 +7,19 @@ toc: true
 
 ## Background
 
-Because of the networking improvement and the influent of the COVID-19, live streaming has become the hottest technology on the Internet, again.
+Because of network improvements and the impact of COVID-19, live streaming has become the hottest technology on the Internet, again.
 
 ![](/uploads/persister-how-to-build-a-scalable-live-streaming-interactive-service--e6c9d24ely1h0obi03jucj20yv0u0dkg.jpg)
 
-Fortunately, I have been participating in building a live streaming platform. In other words, I also have some experience in this domain. Today I am gonna talk about the "Interactive Service" of live streaming, my most familiar part of the platform.
+Fortunately, I have been participating in building a live streaming platform. In other words, I also have some experience in this domain. Today I am going to talk about the "Interactive Service" of live streaming, my most familiar part of the platform.
 
-At first, I have to define the "Interactive Service". Commonly, people always split the live streaming platform into two parts: "Video Steaming" and "Interactive Service".
+At first, I have to define the "Interactive Service". Commonly, people always split the live streaming platform into two parts: "Video Streaming" and "Interactive Service".
 
 ![](/uploads/persister-how-to-build-a-scalable-live-streaming-interactive-service--e6c9d24ely1h0oblby6l5j20z60u0tbv.jpg)
 
-"Video Streaming" means the audio and video that people can instantly watch and hear. "Video Streaming" is the bastion of live streaming, we can't see anything and hear any word from the anchor without it, the live streaming totally becomes a boring group chat.
+"Video Streaming" means the audio and video that people can instantly watch and hear. "Video Streaming" is the foundation of live streaming, we can't see anything and hear any word from the anchor without it, the live streaming totally becomes a boring group chat.
 
-"Interactive Service" means all the other parts without "Video Streaming". Almost everything you can join to the live streaming is the result of "Interactive Service". For example, comments, gifts, e-commerce notifications, etc. "Interactive Service" gives live streaming a soul so that live streaming is never a monologue of the anchor, it's a party between the anchor and all of the audiences.
+"Interactive Service" means all the other parts without "Video Streaming". Almost everything you can join to the live streaming is the result of "Interactive Service". For example, comments, gifts, e-commerce notifications, etc. "Interactive Service" gives live streaming a soul so that live streaming is never a monologue of the anchor, it's a party between the anchor and all audiences.
 
 ## Interactive Service
 
@@ -27,9 +27,9 @@ In my opinion, "Interactive Service" is a full-feature eco-system.
 
 Anchors and audiences can generate signals to it, and it would deliver the signals to the other people in the live room. For example, the audience foo can comment on a signal "You look good" to the "Interactive Service", and "Interactive Service" will broadcast this signal to the other people after a while.
 
-On the other hand, "Interactive Service" can generate some event by itself. For example, "Interactive Service" will broadcast the exact number of users online of every live room by period, so that people can see how many people do the live room has now.
+On the other hand, "Interactive Service" can also generate events on its own. For example, "Interactive Service" will broadcast the exact number of users online of every live room periodically, so that people can see how many people do the live room has now.
 
-How to build an "Interactive Service" to deliver such signals in a safe, quick, and economic way, are the core parts we discuss in this article.
+How to build an "Interactive Service" that delivers these signals safely, quickly, and cost-effectively is the core topic of this article.
 
 - Safe
   - "Interactive Service" should check the authority of the request/connection
@@ -42,19 +42,19 @@ How to build an "Interactive Service" to deliver such signals in a safe, quick, 
 
 ## Signal Types
 
-Before we discuss the different modelings of "Interactive Service", we should talk about 3 types of signals whiches should implement in different ways.
+Before we discuss the different modelings of "Interactive Service", we should talk about 3 types of signals that should be implemented in different ways.
 
 ### State Sync Signal
 
-The clients should init some state just after entering the live room. When the states have been changed, clients should be noticed and do something about these changes.
+Clients should initialize some state just after entering the live room. When the states have been changed, clients should be noticed and do something about these changes.
 
-A modal implementation is using "Total and Partial Version" to describe state changes of the business state updating of live streaming.
+A common implementation is using "Total and Partial Version" to describe state changes of the business state updating of live streaming.
 
 In this implementation, servers and clients should store the total version and partial versions. Clients should fetch the total version by interval and then fetch the outdated partial versions if the fetched total version is different from the local total version.
 
 ![](/uploads/persister-how-to-build-a-scalable-live-streaming-interactive-service--e6c9d24ely1h0oc8bkeruj21d90u078y.jpg)
 
-We call this model `SS Signal` for a shortcut.
+We call this model `SS Signal` for short.
 
 ### Time Series Signal
 
@@ -66,11 +66,11 @@ We can use several ways to implement time-series signals. But there are two diff
 
 ![](/uploads/persister-how-to-build-a-scalable-live-streaming-interactive-service--e6c9d24ely1h0oc8tju01j219g0u0djh.jpg)
 
-We call this model `TS Signal` for a shortcut.
+We call this model `TS Signal` for short.
 
 ### Peer Delivery Signal
 
-SS signal and Ts signal are designed for all of the people in the same live room. When one of the state change or some action happen, these signals should be delivered to all of the clients in these live room. But peer signals are designed for just some of the people in the live room.
+SS signal and TS signal are designed for all of the people in the same live room. When one of the state change or some action happen, these signals should be delivered to all of the clients in a live room. But peer signals are designed for just some of the people in the live room.
 
 We could use signals with some filters to implement peer signals, but it will have lots of performance issues.
 
@@ -101,7 +101,7 @@ As we all know, CDN services can achieve higher performance and less latency. So
 
 ### Server-Push Modeling
 
-When the live room is updated fastly, using a custom application layer based on a proper transport layer is considerable.
+When the live room is updated rapidly, using a custom application layer based on a proper transport layer is considerable.
 
 In this way, we could choose WebSocket to reach more compatibility, or use QUIC to reach more efficiency, or just use TCP typically.
 
@@ -111,14 +111,14 @@ In HTTP Server, each server is stateless so it's easier to implement the load ba
 
 In the C/S Modeling part, we talked about the grouping of HTTP Server, the conception works in Server-Push Modeling, too. There are several models of this conception.
 
-- Split up the server into some groups, and each group has its endpoint, the clients choose the targe endpoint by the id of the live room
+- Split up the server into some groups, and each group has its endpoint, the clients choose the target endpoint by the id of the live room
 - Using or implementing an application-level load balancing algorithm.
 
 ![](/uploads/persister-how-to-build-a-scalable-live-streaming-interactive-service--e6c9d24ely1h0oc72dn9yj21fc0u0afn.jpg)
 
 ## Summary
 
-Buiding a live streaming platform is such a large project, so I cannot write down all of my thoughts in one article.
+Building a live streaming platform is such a large project, so I cannot write down all of my thoughts in one article.
 
 But in this part, we have discussed some core concepts of live streaming.
 

--- a/source/_posts/backend/livestreaming/scalable-interactive-service-2.md
+++ b/source/_posts/backend/livestreaming/scalable-interactive-service-2.md
@@ -7,25 +7,25 @@ toc: true
 
 ## Background
 
-Because of the networking improvement and the influent of the COVID-19, live streaming has become the hottest technology on the Internet, again.
+Because of network improvements and the impact of COVID-19, live streaming has become the hottest technology on the Internet, again.
 
 ![](/uploads/persister-how-to-build-a-scalable-live-streaming-interactive-service--e6c9d24ely1h0obi03jucj20yv0u0dkg.jpg)
 
-In the past article we have discussed signal modeling and interactive modeling, this time we will discuss the scale methods of interactive service.
+In the previous article, we discussed signal and interaction modeling. This time, we will focus on scaling methods for interactive services.
 
 ## Limitations
 
-As we all know, there are simply two kinds of services in the backend, called stateless service and stateful service.
+In backend systems, there are two broad categories of services: stateless and stateful.
 
 Stateless service means that the service processes requests based only on the information relayed with each request and doesn’t rely on information from earlier requests.
 
 Stateful service means that the service processes requests based on the information relayed with each request and information stored from earlier requests.
 
-The biggest difference between stateless service and stateful service is that stateless service can route requests to different instances easily and stateful service can't.
+The biggest difference between stateless service and stateful service is that stateless service can route requests to different instances easily and stateful services cannot.
 
-The stateless services are easy to scale so that the bottleneck of the entire system commonly comes from the stateful parts.
+Stateless services are easier to scale, so system bottlenecks usually come from stateful components.
 
-The interactive service of live streaming is composed of a few parts as I mention below.
+The interactive service of live streaming is composed of a few parts as mentioned below.
 
 - Storages
   - Relational Databases
@@ -39,11 +39,11 @@ The interactive service of live streaming is composed of a few parts as I mentio
 - HTTP Servers
 - Signaling Servers
 
-And today the scaling methods of interactive service are aiming at these parts, too.
+And today the scaling methods for interactive services also target these components.
 
 ## Scaling Methods
 
-The distributed systems are often constructed by several small instances, we can increase the capacity and performance by scaling the instance up. But before scaling it up we have to make our system scalable.
+The distributed systems are often constructed by several small instances, we can increase capacity and performance by scaling instances out. But before scaling out we have to make our system scalable.
 
 ### Relational Databases
 
@@ -69,11 +69,11 @@ When we are querying the database by offline live streaming room id, we can just
 
 We use Redis to implement the structured collections, so the method to scale the structured collections is to scale the Redis servers.
 
-We never use `Redis Cluster` technology as our `Redis Cluster` solution. Conversely, we just use twemproxy to reroute the write and query. So the `Redis Cluster` we talk about below is not as same as the official `Redis Cluster` but the cluster constructed by several Twemproxy, Redis-Master, Redis-Slave, and Redis-Sentinal.
+We never use `Redis Cluster` technology as our `Redis Cluster` solution. Conversely, we just use twemproxy to reroute the write and query. So the `Redis Cluster` we talk about below is not the same as the official `Redis Cluster` but the cluster constructed by several Twemproxy, Redis-Master, Redis-Slave, and Redis-Sentinal.
 
 On the other hand, we often build two same Redis Cluster in different AZ(Available Zone) and assign one of them as the main cluster by config.
 
-The write operation of the main cluster would replica to the secondary cluster by Kafka Message.
+The write operation of the main cluster is replicated to the secondary cluster by Kafka Message.
 
 ![](/uploads/persister-scalable-interactive-service-2--e6c9d24ely1h0ofdhqbrcj215g0u078o.jpg)
 
@@ -89,7 +89,7 @@ Big-key often comes from the write operation of sorted set keys and hash keys. I
 Hot-Key often comes from the read operation, in order to prevent it, we can use these ways below.
 
 - Use another cache to store the result temporarily. For example, we can build a local cache in our service and this local cache will serve all the requests before expired;
-- Storage the key redundantly and choose a key randomly to read. In the general Redis Cluster solution, the different keys will locate in a different Redis-Server, so that all the requests will not be routed in a certain Redis-Server, too.
+- Store keys redundantly and choose a key randomly to read. In the general Redis Cluster solution, the different keys will locate in a different Redis-Server, so that all the requests will not be routed in a certain Redis-Server, too.
 
 ![](/uploads/persister-scalable-interactive-service-2--e6c9d24ely1h0olq9yfdqj21aw0u00wc.jpg)
 
@@ -117,12 +117,12 @@ One more thing worth mentioning is that the hash salts of different Memcached Cl
 
 In this way cache, we will have the highest availability.
 
-- If one Memcached node is down, no cached will be lost because clients will read the lost keys from another Memcached Cluster and write back;
+- If one Memcached node is down, no cache will be lost because clients will read the lost keys from another Memcached Cluster and write back;
 - If two Memcached nodes of different Memcached Clusters are down, only 1/M * 1/N data will be lost. (M, N means the nodes count of the Memcached Clusters)
 
 ### Scheduled Tasks
 
-Processing some business periodically is a very common live streaming backend. Most of the process tasks do have these properties.
+Processing some business periodically is a very common live streaming backend. Most of these processing tasks do have these properties.
 
 - They should know which rooms are ongoing;
 - They would do the logic separate by the live streaming room.
@@ -135,7 +135,7 @@ We can use a service named "OngoingQuery" to protect the databases.
 
 The OngoingQuery service will store all the room ids of ongoing live streaming.
 
-They scan the databases periodically to update the entire cache of themselves, and they the binlog of databases for instantly update. In this way, the cache of the OngoingQuery service will be the same as the data of the database eventually.
+They scan the databases periodically to update the entire cache of themselves, and tail database binlogs for near-real-time updates. In this way, the cache of the OngoingQuery service will be the same as the data of the database eventually.
 
 When we deploy a number of shard tasks for processing some business data, the shard tasks will register themselves to ZooKeeper at first, and then run periodically to do these things.
 
@@ -160,9 +160,9 @@ We can use a virtual account to improve the transporting performance.
 
 When the live streaming room begins, we will create a virtual account for this live streaming room in each database of user balance.
 
-The gifting operation during the live streaming will be transportation between the audience account and the virtual account of the database which the audience account belongs to.
+The gifting operation during the live streaming will be transfers between the audience account and the virtual account of the database which the audience account belongs to.
 
-When the live stream room end, the service named "Settler" will collect all of the virtual accounts and do the distributed transaction between virtual accounts and the anchor account.
+When the live-stream room ends, the service named "Settler" will collect all of the virtual accounts and do the distributed transaction between virtual accounts and the anchor account.
 
 ### HTTP Service
 
@@ -176,7 +176,7 @@ We have talked about this in the [How to Build a Scalable Live Streaming Interac
 
 ## Summary
 
-In this article, we have discussed the scale strategies of the stateful services of live streaming interactive services. Some people also called these strategies "sharding strategy".
+In this article, we have discussed the scaling strategies of the stateful services of live streaming interactive services. Some people also called these strategies "sharding strategy".
 
 All of these things have a core concept commonly -- "Split the big thing into small things", oh we have learned it in our university, isn't it?
 

--- a/source/_posts/backend/rate-limiter-in-action.md
+++ b/source/_posts/backend/rate-limiter-in-action.md
@@ -5,11 +5,11 @@ categories: Backend
 toc: true
 ---
 
-The backend systems which have lots of request per second always need a local rate limiter to protect themself.
+Backend systems that handle many requests per second often need a local rate limiter to protect themselves.
 
-Which "local" means that this rate limiter worked in only this process and not shared with another.
+Here, "local" means the limiter works only within a single process and is not shared across processes.
 
-Here are some local rate limiter used in prodction evironment.
+Here are some local rate-limiting strategies commonly used in production environments.
 
 - Fixed Window
 - Floating Window
@@ -22,14 +22,14 @@ And we will discuss them one by one.
 
 Fixed Window means that we can split a time to some window, and perform the action for a limit in a window.
 
-The disatvantage is that the throughput of this system can be not such steady.
-Image this scenario, we have a rate limiter for 1000 per second, and perform not one request in first 999ms.
-After this, we perform 1000 request in 1ms, all of these request will be granted.
-And then we perform 1000 request in 1ms too, as we can see, the latest 1000 requests will be granted too, because there two part of request matches the different time window.
+The disadvantage is that system throughput may be uneven.
+Imagine this scenario: we set a rate limit of 1000 requests per second and receive no requests in the first 999 ms.
+Then, 1000 requests arrive within 1 ms, and all of them are granted.
+Right after that, another 1000 requests arrive within 1 ms and can also be granted because they fall into a new window.
 
 We can reduce this defect by splitting out the time window smaller.
 For example, when we need a rate limiter for 1000 per second, we can split one second as 100 "tenMs" then limit 10 actions per "tenMs".
-As we can see, the smaller you slit the time window, the smoother it rate limiter can be.
+As we can see, the smaller you split the time window, the smoother the limiter behavior becomes.
 
 After discussing the concept of Fixed Window rate limiting, it's beneficial to provide a code example. Here is a simple implementation in Java:
 
@@ -136,11 +136,11 @@ public class LeakyBucketRateLimiter {
 
 ## Token Bucket
 
-Token Bucket means that we have a bucket which contains lots of bucket, and there is another thread will supply the token in a fixed rate at the same time.
+Token Bucket means we have a bucket that holds tokens, and tokens are replenished at a fixed rate.
 
-Backend system will take a token from the bucket for per request. When the bucket is run out of token, the request will be blocked.
+The backend system consumes one token per request. When the bucket runs out of tokens, requests are rejected or delayed.
 
-Token Bucket seems like Leaky Bucket but can be more effective, because we can just record the number of bucket and the latest time when we supply the bucket, instead of using a token-supplier thread.
+Token Bucket seems like Leaky Bucket but can be more effective, because we can track only the token count and the last refill timestamp instead of running a dedicated refill thread.
 
 Here is a simple implementation.
 


### PR DESCRIPTION
## Summary
- polish English grammar and wording in several backend posts
- keep technical meaning unchanged while improving readability
- normalize several terms (e.g., cancellation/canceled)

## Files updated
- source/_posts/backend/http-graceful-cancelation.md
- source/_posts/backend/innodb-locks.md
- source/_posts/backend/rate-limiter-in-action.md
- source/_posts/backend/livestreaming/scalable-interactive-service-1.md
- source/_posts/backend/livestreaming/scalable-interactive-service-2.md

## Notes
- this PR focuses on language polish only; no code samples or architecture recommendations were changed.
