### PR TITLE
Polish wording in live streaming interactive service posts

### DIFF
--- a/source/_posts/backend/livestreaming/scalable-interactive-service-1.md
+++ b/source/_posts/backend/livestreaming/scalable-interactive-service-1.md
@@ -7,7 +7,7 @@ toc: true
 
 ## Background
 
-With faster networks and the push from COVID-era remote life, live streaming has become popular again.
+With faster networks and the push from COVID-era remote life, live streaming has seen a resurgence.
 
 ![](/uploads/persister-how-to-build-a-scalable-live-streaming-interactive-service--e6c9d24ely1h0obi03jucj20yv0u0dkg.jpg)
 
@@ -23,7 +23,7 @@ First, let’s define what “Interactive Service” means. A useful mental mode
 
 ## Interactive Service
 
-I think of an “Interactive Service” as a full-featured ecosystem.
+I treat the “Interactive Service” as an event distribution layer plus a set of business workflows.
 
 Both hosts and viewers generate signals (events/messages) to it, and it delivers those signals to other participants in the room. For example, a viewer `foo` can send a comment like “You look good”, and the interactive service will broadcast that comment to everyone else shortly after.
 

--- a/source/_posts/backend/livestreaming/scalable-interactive-service-2.md
+++ b/source/_posts/backend/livestreaming/scalable-interactive-service-2.md
@@ -7,7 +7,7 @@ toc: true
 
 ## Background
 
-With faster networks and the push from COVID-era remote life, live streaming has become popular again.
+With faster networks and the push from COVID-era remote life, live streaming has seen a resurgence.
 
 ![](/uploads/persister-how-to-build-a-scalable-live-streaming-interactive-service--e6c9d24ely1h0obi03jucj20yv0u0dkg.jpg)
 
@@ -43,7 +43,7 @@ The scaling methods discussed below largely target these components.
 
 ## Scaling Methods
 
-Distributed systems are usually built from many small instances. To increase capacity and throughput, we scale out by adding instances—but that only works if each component is designed to scale.
+Most distributed systems scale by adding instances, but that only works when each component can actually scale out.
 
 ### Relational Databases
 
@@ -94,7 +94,7 @@ Hot keys usually come from reads. To mitigate hot keys, you can:
 
 On large social-style platforms, hotspot detection plus special-case policies (rate limits, circuit breakers, pre-warming) are also common tools.
 
-### K-V Caches
+### Key-Value Caches
 
 We use Memcached as our key-value cache. Most values cached in Memcached are derived from the relational databases.
 
@@ -145,7 +145,7 @@ When we deploy a sharded job (multiple worker processes), workers register thems
 
 With this partitioning abstraction, one logical job can be split across multiple processes and run concurrently.
 
-### Account Transporting
+### Gift Settlement
 
 Almost every live streaming platform will support gift features.
 
@@ -179,7 +179,7 @@ In this article, we discussed scaling strategies for the stateful parts of a liv
 
 The common theme is simple: split a big thing into smaller, independent pieces.
 
-In the next post, I’ll share my thoughts on building a multi-region (or cross-region) live streaming platform.
+If there is interest, I can write a follow-up on building a multi-region (or cross-region) live streaming platform.
 
 ## References
 


### PR DESCRIPTION
## What changed

This PR applies a minimal wording polish to two English posts:

- `source/_posts/backend/livestreaming/scalable-interactive-service-1.md`
- `source/_posts/backend/livestreaming/scalable-interactive-service-2.md`

## Highlights

- Replaced "has become popular again" with "has seen a resurgence" in both posts.
- Made the Part I "Interactive Service" definition more concrete and technical.
- Smoothed one sentence in Part II to sound less textbook-like.
- Renamed section titles for clearer, more natural wording:
  - `K-V Caches` -> `Key-Value Caches`
  - `Account Transporting` -> `Gift Settlement`
- Changed the Part II ending to avoid implying Part III is already scheduled.

No architecture, logic, or technical claims were changed.